### PR TITLE
[Custom Nodes and Edges] Add k9db-typed nodes and edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ For init, you should be able to see the following template:
 ![Init Phase](readme_imgs/init.png)
 
 ## Canvas TODO
-1. Schema button should have a pop-up window as a text box
-2. Validate button should have a pop-up window to display alert message
-3. Decompose flow into node and edges
-4. Flow should render the node and edges according to the parser result (use fake data at the test stage)
+
+* [x] Decompose flow into node and edges
+* [x] Add static support for K9DB edges and nodes
+* [ ] Flow should dynamically render the nodes and edges according to the parser result (use fake data at the test stage)
+  * [ ] Dynamically generate source and target anchors for each node
+  * [ ] Dynamically position the nodes to prevent intersection/overlaps... 
+* [ ] Schema button should have a pop-up window as a text box
+* [ ] Schema button should be able to send the input to the parser
+* [ ] Validate button should have a pop-up window to display alert message
+* [ ] Validate button should be able to send the existing graph data as arguments to `validate` function to valid the existing graph. 

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/AccessedByEdge.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/AccessedByEdge.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+} from "reactflow";
+
+import "./edge.css";
+
+const onEdgeClick = (id) => {
+  console.log("clicked owns edge: " + id);
+};
+
+export default function AccessedByEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+ 
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={style}
+      />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            fontSize: 12,
+            // everything inside EdgeLabelRenderer has no pointer events by default
+            // if you have an interactive element, set pointer-events: all
+            pointerEvents: "all",
+          }}
+          className="nodrag nopan"
+        >
+          <button className="edgeaccessedby" onClick={() => onEdgeClick(id)}>
+            ACCESSED_BY
+          </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/AccessesEdge.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/AccessesEdge.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+} from "reactflow";
+
+import "./edge.css";
+
+const onEdgeClick = (id) => {
+  console.log("clicked owns edge: " + id);
+};
+
+export default function AccessesEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+ 
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={style}
+      />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            fontSize: 12,
+            // everything inside EdgeLabelRenderer has no pointer events by default
+            // if you have an interactive element, set pointer-events: all
+            pointerEvents: "all",
+          }}
+          className="nodrag nopan"
+        >
+          <button className="edgeaccesses" onClick={() => onEdgeClick(id)}>
+            ACCESSES         
+            </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/OwnedByEdge.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/OwnedByEdge.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+} from "reactflow";
+
+import "./edge.css";
+
+const onEdgeClick = (id) => {
+  console.log("clicked owns edge: " + id);
+};
+
+export default function OwnedByEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+ 
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={style}
+      />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            fontSize: 12,
+            // everything inside EdgeLabelRenderer has no pointer events by default
+            // if you have an interactive element, set pointer-events: all
+            pointerEvents: "all",
+          }}
+          className="nodrag nopan"
+        >
+          <button className="edgeownedby" onClick={() => onEdgeClick(id)}>
+            OWNED_BY
+          </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/OwnsEdge.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/OwnsEdge.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+} from "reactflow";
+
+import "./edge.css";
+
+const onEdgeClick = (id) => {
+  console.log("clicked owns edge: " + id);
+};
+
+export default function OwnsEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+ 
+
+  return (
+    <>
+      <BaseEdge
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={style}
+      />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            fontSize: 12,
+            // everything inside EdgeLabelRenderer has no pointer events by default
+            // if you have an interactive element, set pointer-events: all
+            pointerEvents: "all",
+          }}
+          className="nodrag nopan"
+        >
+          <button className="edgeowns" onClick={() => onEdgeClick(id)}>
+            OWNS
+          </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/edge.css
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/edge.css
@@ -1,9 +1,86 @@
+/* Accesses Edge Style */
+.edgeaccesses:hover {
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.08);
+}
+
+.edgeaccesses {
+  background-color: #F5FF90;
+  border-radius: 10px;
+  color: #000;
+  cursor: pointer;
+  font-weight:500;
+  padding: 3px 8px;
+  text-align: center;
+  transition: 200ms;
+  width: 120%;
+  box-sizing: border-box;
+  border: 0;
+  font-size: 10px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  font-family: "Gill Sans", sans-serif;
+  border: 1.2px solid #fff;
+}
+
+/* AccessedBy Edge Style */
+.edgeaccessedby:hover {
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.08);
+}
+
+.edgeaccessedby {
+  background-color: #D6FFB7;
+  border-radius: 10px;
+  color: #000;
+  cursor: pointer;
+  font-weight:500;
+  padding: 3px 8px;
+  text-align: center;
+  transition: 200ms;
+  width: 120%;
+  box-sizing: border-box;
+  border: 0;
+  font-size: 10px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  font-family: "Gill Sans", sans-serif;
+  border: 1.2px solid #fff;
+}
+
+/* Owns Edge Style */
 .edgeowns:hover {
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.08);
 }
 
 .edgeowns {
-  background-color: #fff000;
+  background-color: #FF9F1C;
+  border-radius: 10px;
+  color: #000;
+  cursor: pointer;
+  font-weight:500;
+  padding: 3px 8px;
+  text-align: center;
+  transition: 200ms;
+  width: 120%;
+  box-sizing: border-box;
+  border: 0;
+  font-size: 10px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  font-family: "Gill Sans", sans-serif;
+  border: 1.2px solid #fff;
+}
+
+
+/* OwnedBy Edge Style */
+.edgeownedby:hover {
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.08);
+}
+
+.edgeownedby {
+  background-color: #FFC15E;
   border-radius: 10px;
   color: #000;
   cursor: pointer;

--- a/k9db-visualizer/src/components/FlowComponent/EdgeComponent/edge.css
+++ b/k9db-visualizer/src/components/FlowComponent/EdgeComponent/edge.css
@@ -1,0 +1,23 @@
+.edgeowns:hover {
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.08);
+}
+
+.edgeowns {
+  background-color: #fff000;
+  border-radius: 10px;
+  color: #000;
+  cursor: pointer;
+  font-weight:500;
+  padding: 3px 8px;
+  text-align: center;
+  transition: 200ms;
+  width: 120%;
+  box-sizing: border-box;
+  border: 0;
+  font-size: 10px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  font-family: "Gill Sans", sans-serif;
+  border: 1.2px solid #fff;
+}

--- a/k9db-visualizer/src/components/FlowComponent/Edges.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Edges.tsx
@@ -1,0 +1,88 @@
+import { MarkerType } from 'reactflow';
+
+const ownsMarkerEnd = {
+  type: MarkerType.ArrowClosed,
+  width: 18,
+  height: 20,
+};
+
+const edgeStyle = {
+  strokeWidth: 1.2,
+}
+
+const Edges = () => {
+
+  return (
+    [
+      {
+        id: 'edges-e1-2',
+        source: 'edges-1',
+        target: 'edges-2',
+        type: 'ownsedge',
+        markerEnd: ownsMarkerEnd,
+        style: edgeStyle
+      },
+      {
+        id: 'edges-e2-2a',
+        source: 'edges-2',
+        target: 'edges-2a',
+        type: 'smoothstep',
+        label: 'smoothstep edge',
+      },
+      {
+        id: 'edges-e2-3',
+        source: 'edges-2',
+        target: 'edges-3',
+        type: 'step',
+        label: 'step edge',
+      },
+      {
+        id: 'edges-e3-4',
+        source: 'edges-3',
+        target: 'edges-4',
+        type: 'straight',
+        label: 'straight edge',
+      },
+      {
+        id: 'edges-e3-3a',
+        source: 'edges-3',
+        target: 'edges-3a',
+        type: 'straight',
+        label: 'label only edge',
+        style: { stroke: 'none' },
+      },
+      {
+        id: 'edges-e3-5',
+        source: 'edges-4',
+        target: 'edges-5',
+        animated: true,
+        label: 'animated styled edge',
+        style: { stroke: 'red' },
+      },
+      {
+        id: 'edges-e5-6',
+        source: 'edges-5',
+        target: 'edges-6',
+        label: 'styled label',
+        labelStyle: { fill: 'red', fontWeight: 700 },
+        markerEnd: {
+          type: MarkerType.Arrow,
+        },
+      },
+      {
+        id: 'edges-e5-7',
+        source: 'edges-5',
+        target: 'edges-7',
+        label: 'label with styled bg',
+        labelBgPadding: [8, 4],
+        labelBgBorderRadius: 4,
+        labelBgStyle: { fill: '#FFCC00', color: '#fff', fillOpacity: 0.7 },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+        },
+      },
+    ]
+  )
+}
+
+export default Edges

--- a/k9db-visualizer/src/components/FlowComponent/Edges.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Edges.tsx
@@ -1,4 +1,4 @@
-import { MarkerType } from 'reactflow';
+import { MarkerType } from "reactflow";
 
 const ownsMarkerEnd = {
   type: MarkerType.ArrowClosed,
@@ -26,84 +26,43 @@ const accessedbyMarkerEnd = {
 
 const edgeStyle = {
   strokeWidth: 1.2,
-}
+};
 
 const Edges = () => {
+  return [
+    {
+      id: "edges-e1-2",
+      source: "1",
+      target: "2",
+      type: "ownsedge",
+      markerEnd: ownsMarkerEnd,
+      style: edgeStyle,
+    },
+    {
+      id: "edges-e2-2a",
+      source: "2",
+      target: "3",
+      type: "ownedbyedge",
+      markerEnd: ownedbyMarkerEnd,
+      style: edgeStyle,
+    },
+    {
+      id: "edges-e2-3",
+      source: "2",
+      target: "4",
+      type: "accessesedge",
+      markerEnd: accessesMarkerEnd,
+      style: edgeStyle,
+    },
+    {
+      id: "edges-e3-4",
+      source: "4",
+      target: "5",
+      type: "accessedbyedge",
+      markerEnd: accessedbyMarkerEnd,
+      style: edgeStyle,
+    },
+  ];
+};
 
-  return (
-    [
-      {
-        id: 'edges-e1-2',
-        source: 'edges-1',
-        target: 'edges-2',
-        type: 'ownsedge',
-        markerEnd: ownsMarkerEnd,
-        style: edgeStyle
-      },
-      {
-        id: 'edges-e2-2a',
-        source: 'edges-2',
-        target: 'edges-2a',
-        type: 'ownedbyedge',
-        markerEnd: ownedbyMarkerEnd,
-        style: edgeStyle
-      },
-      {
-        id: 'edges-e2-3',
-        source: 'edges-2',
-        target: 'edges-3',
-        type: 'accessesedge',
-        markerEnd: accessesMarkerEnd,
-        style: edgeStyle
-      },
-      {
-        id: 'edges-e3-4',
-        source: 'edges-3',
-        target: 'edges-4',
-        type: 'accessedbyedge',
-        markerEnd: accessedbyMarkerEnd,
-        style: edgeStyle
-      },
-      {
-        id: 'edges-e3-3a',
-        source: 'edges-3',
-        target: 'edges-3a',
-        type: 'straight',
-        label: 'label only edge',
-        style: { stroke: 'none' },
-      },
-      {
-        id: 'edges-e3-5',
-        source: 'edges-4',
-        target: 'edges-5',
-        animated: true,
-        label: 'animated styled edge',
-        style: { stroke: 'red' },
-      },
-      {
-        id: 'edges-e5-6',
-        source: 'edges-5',
-        target: 'edges-6',
-        label: 'styled label',
-        labelStyle: { fill: 'red', fontWeight: 700 },
-        markerEnd: {
-          type: MarkerType.Arrow,
-        },
-      },
-      {
-        id: 'edges-e5-7',
-        source: 'edges-5',
-        target: 'edges-7',
-        label: 'label with styled bg',
-        labelBgPadding: [8, 4],
-        labelBgBorderRadius: 4,
-        labelBgStyle: { fill: '#FFCC00', color: '#fff', fillOpacity: 0.7 },
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-        },
-      },
-    ]
-  )
-}
-
-export default Edges
+export default Edges;

--- a/k9db-visualizer/src/components/FlowComponent/Edges.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Edges.tsx
@@ -6,6 +6,24 @@ const ownsMarkerEnd = {
   height: 20,
 };
 
+const ownedbyMarkerEnd = {
+  type: MarkerType.ArrowClosed,
+  width: 18,
+  height: 20,
+};
+
+const accessesMarkerEnd = {
+  type: MarkerType.ArrowClosed,
+  width: 18,
+  height: 20,
+};
+
+const accessedbyMarkerEnd = {
+  type: MarkerType.ArrowClosed,
+  width: 18,
+  height: 20,
+};
+
 const edgeStyle = {
   strokeWidth: 1.2,
 }
@@ -26,22 +44,25 @@ const Edges = () => {
         id: 'edges-e2-2a',
         source: 'edges-2',
         target: 'edges-2a',
-        type: 'smoothstep',
-        label: 'smoothstep edge',
+        type: 'ownedbyedge',
+        markerEnd: ownedbyMarkerEnd,
+        style: edgeStyle
       },
       {
         id: 'edges-e2-3',
         source: 'edges-2',
         target: 'edges-3',
-        type: 'step',
-        label: 'step edge',
+        type: 'accessesedge',
+        markerEnd: accessesMarkerEnd,
+        style: edgeStyle
       },
       {
         id: 'edges-e3-4',
         source: 'edges-3',
         target: 'edges-4',
-        type: 'straight',
-        label: 'straight edge',
+        type: 'accessedbyedge',
+        markerEnd: accessedbyMarkerEnd,
+        style: edgeStyle
       },
       {
         id: 'edges-e3-3a',

--- a/k9db-visualizer/src/components/FlowComponent/Flow.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Flow.tsx
@@ -9,28 +9,37 @@ import ReactFlow, {
 } from "reactflow";
 import ControlPanel from "./ControlPanelComponent/ControlPanel";
 
-const initialNodes = [
-  { id: "1", position: { x: 0, y: 0 }, data: { label: "1" } },
-  { id: "2", position: { x: 0, y: 100 }, data: { label: "2" } },
-];
-const initialEdges = [{ id: "e1-2", source: "1", target: "2" }];
+import initialNodes from "./Nodes.js";
+import initialEdges from "./Edges.js";
+import OwnsEdge from "./EdgeComponent/OwnsEdge";
+
+const edgeTypes = {
+  ownsedge: OwnsEdge,
+};
+
 
 const Flow = () => {
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
   const onConnect = useCallback(
     (params) => setEdges((eds) => addEdge(params, eds)),
-    [setEdges]
+    []
   );
+
   return (
     <div style={{ width: "100vw", height: "100vh", alignSelf: "center" }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        edgeTypes={edgeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        snapToGrid={true}
+        fitView
+        attributionPosition="top-right"
       >
         <ControlPanel />
         <MiniMap />

--- a/k9db-visualizer/src/components/FlowComponent/Flow.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Flow.tsx
@@ -15,17 +15,22 @@ import OwnsEdge from "./EdgeComponent/OwnsEdge";
 import OwnedByEdge from "./EdgeComponent/OwnedByEdge";
 import AccessesEdge from "./EdgeComponent/AccessesEdge";
 import AccessedByEdge from "./EdgeComponent/AccessedByEdge";
+import DataSubjectNode from "./NodeComponent/DataSubjectNode";
+import NonDataSubjectNode from "./NodeComponent/NonDataSubjectNode";
 
 const edgeTypes = {
   ownsedge: OwnsEdge,
   ownedbyedge: OwnedByEdge,
   accessesedge: AccessesEdge,
-  accessedbyedge: AccessedByEdge
+  accessedbyedge: AccessedByEdge,
 };
 
+const nodeTypes = {
+  datasubjectnode: DataSubjectNode,
+  nondatasubjectnode: NonDataSubjectNode,
+};
 
 const Flow = () => {
-
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
@@ -40,6 +45,7 @@ const Flow = () => {
         nodes={nodes}
         edges={edges}
         edgeTypes={edgeTypes}
+        nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
@@ -48,7 +54,12 @@ const Flow = () => {
         attributionPosition="top-right"
       >
         <ControlPanel />
-        <MiniMap />
+        <MiniMap
+          nodeColor={(n) => {
+            if (n.type === "datasubjectnode") return "#423E37";
+            return "#eee";
+          }}
+        />
         <Background gap={12} size={1} />
       </ReactFlow>
     </div>

--- a/k9db-visualizer/src/components/FlowComponent/Flow.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Flow.tsx
@@ -12,9 +12,15 @@ import ControlPanel from "./ControlPanelComponent/ControlPanel";
 import initialNodes from "./Nodes.js";
 import initialEdges from "./Edges.js";
 import OwnsEdge from "./EdgeComponent/OwnsEdge";
+import OwnedByEdge from "./EdgeComponent/OwnedByEdge";
+import AccessesEdge from "./EdgeComponent/AccessesEdge";
+import AccessedByEdge from "./EdgeComponent/AccessedByEdge";
 
 const edgeTypes = {
   ownsedge: OwnsEdge,
+  ownedbyedge: OwnedByEdge,
+  accessesedge: AccessesEdge,
+  accessedbyedge: AccessedByEdge
 };
 
 

--- a/k9db-visualizer/src/components/FlowComponent/NodeComponent/DataSubjectNode.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/NodeComponent/DataSubjectNode.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Handle, NodeProps, Position } from "reactflow";
+import "./node.css";
+
+export default function DataSubjectNode({ data }: NodeProps) {
+  return (
+    <>
+      <div className="datasubjectnode">{data.label}</div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        style={{ background: "#555" }}
+        isConnectable={false}
+      />
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/NodeComponent/NonDataSubjectNode.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/NodeComponent/NonDataSubjectNode.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Handle, NodeProps, Position } from "reactflow";
+import "./node.css";
+
+export default function NonDataSubjectnode({ data }: NodeProps) {
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Top}
+        style={{ background: "#555" }}
+        isConnectable={false}
+      />
+      <div className="datasubjectnode">{data.label}</div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        style={{ background: "#555" }}
+        isConnectable={false}
+      />
+    </>
+  );
+}

--- a/k9db-visualizer/src/components/FlowComponent/NodeComponent/node.css
+++ b/k9db-visualizer/src/components/FlowComponent/NodeComponent/node.css
@@ -1,0 +1,42 @@
+.react-flow__node-datasubjectnode {
+    text-align: center;
+    border: 1.7px solid #423E37;
+    padding: 5px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-family: "Gill Sans", sans-serif;
+    transition: 200ms;
+    width: fit-content;
+    min-width: 10%;
+    height: fit-content;
+    font-weight: 500;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 0.25em 0.5em;
+    box-shadow: 1px 1px 0px 0px #423E37, 2px 2px 0px 0px #423E37, 3px 3px 0px 0px #423E37, 4px 4px 0px 0px #423E37;
+}
+
+.react-flow__node-nondatasubjectnode {
+    text-align: center;
+    padding: 5px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-family: "Gill Sans", sans-serif;
+    transition: 200ms;
+    width: fit-content;
+    min-width: 10%;
+    height: fit-content;
+    font-weight: 500;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    border: 1.7px solid #423E37;
+    padding: 0.25em 0.5em;
+}
+
+.react-flow__node-datasubjectnode:hover {
+    box-shadow: 0 0 2px 2px rgba(50, 49, 49, 0.13);
+}
+
+.react-flow__node-nondatasubjectnode:hover {
+    box-shadow: 0 0 2px 2px rgba(50, 49, 49, 0.13);
+}

--- a/k9db-visualizer/src/components/FlowComponent/Nodes.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Nodes.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const Nodes = () => {
+  return  [
+    {
+      id: 'edges-1',
+      type: 'input',
+      data: { label: 'Input 1' },
+      position: { x: 250, y: 0 },
+    },
+    { id: 'edges-2', data: { label: 'Node 2' }, position: { x: 150, y: 100 } },
+    { id: 'edges-2a', data: { label: 'Node 2a' }, position: { x: 0, y: 180 } },
+    { id: 'edges-3', data: { label: 'Node 3' }, position: { x: 250, y: 200 } },
+    { id: 'edges-4', data: { label: 'Node 4' }, position: { x: 400, y: 300 } },
+    { id: 'edges-3a', data: { label: 'Node 3a' }, position: { x: 150, y: 300 } },
+    { id: 'edges-5', data: { label: 'Node 5' }, position: { x: 250, y: 400 } },
+    {
+      id: 'edges-6',
+      type: 'output',
+      data: { label: 'Output 6' },
+      position: { x: 50, y: 550 },
+    },
+    {
+      id: 'edges-7',
+      type: 'output',
+      data: { label: 'Output 7' },
+      position: { x: 250, y: 550 },
+    },
+  ]
+};
+
+export default Nodes;

--- a/k9db-visualizer/src/components/FlowComponent/Nodes.tsx
+++ b/k9db-visualizer/src/components/FlowComponent/Nodes.tsx
@@ -1,32 +1,36 @@
-import React from "react";
-
 const Nodes = () => {
-  return  [
+  return [
     {
-      id: 'edges-1',
-      type: 'input',
-      data: { label: 'Input 1' },
+      id: "1",
+      type: "datasubjectnode",
+      data: { label: "user", handleCount: 2 },
       position: { x: 250, y: 0 },
     },
-    { id: 'edges-2', data: { label: 'Node 2' }, position: { x: 150, y: 100 } },
-    { id: 'edges-2a', data: { label: 'Node 2a' }, position: { x: 0, y: 180 } },
-    { id: 'edges-3', data: { label: 'Node 3' }, position: { x: 250, y: 200 } },
-    { id: 'edges-4', data: { label: 'Node 4' }, position: { x: 400, y: 300 } },
-    { id: 'edges-3a', data: { label: 'Node 3a' }, position: { x: 150, y: 300 } },
-    { id: 'edges-5', data: { label: 'Node 5' }, position: { x: 250, y: 400 } },
     {
-      id: 'edges-6',
-      type: 'output',
-      data: { label: 'Output 6' },
-      position: { x: 50, y: 550 },
+      id: "2",
+      type: "nondatasubjectnode",
+      data: { label: "STORYssdsadasdsasss", handleCount: 2 },
+      position: { x: 150, y: 100 },
     },
     {
-      id: 'edges-7',
-      type: 'output',
-      data: { label: 'Output 7' },
-      position: { x: 250, y: 550 },
+      id: "3",
+      type: "nondatasubjectnode",
+      data: { label: "TAGGING", handleCount: 2 },
+      position: { x: 0, y: 180 },
     },
-  ]
+    {
+      id: "4",
+      type: "nondatasubjectnode",
+      data: { label: "TAG", handleCount: 2 },
+      position: { x: 250, y: 200 },
+    },
+    {
+      id: "5",
+      type: "nondatasubjectnode",
+      data: { label: "TEST", handleCount: 2 },
+      position: { x: 400, y: 300 },
+    },
+  ];
 };
 
 export default Nodes;


### PR DESCRIPTION
Added basic support for k9db-typed nodes and edges. 

Styles could be found in `edge.css` and `node.css`.

The current implementation **does not** support dynamic rendering.

The canvas should look like this (this graph is not a valid k9db DOG):
<img width="1101" alt="image" src="https://github.com/mingchao-zhang/K9db-Visualizer/assets/57975957/87ced2d1-f2c4-4f92-942f-4f3ebcd373ae">
