### PR TITLE
Refactor all external-facing functions into interface.js

### DIFF
--- a/src/components/FlowComponent/ControlPanelComponent/MyControlButton.tsx
+++ b/src/components/FlowComponent/ControlPanelComponent/MyControlButton.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { ControlButton } from "reactflow";
 import { PiUploadSimpleBold, PiCheckFatFill } from "react-icons/pi";
 import { MyModal } from "../ModalComponent/MyModal";
-import parse from "../../../../utils/parse";
+import { parse } from "../../../../utils/parse";
 import splitTablesEdges from "../../../../utils/splitTableEdges";
 
 const MyControlButton = ({ name, handleParsedSchema, handleStateChange }) => {
@@ -16,6 +16,7 @@ const MyControlButton = ({ name, handleParsedSchema, handleStateChange }) => {
   const handleSubmit = () => {
     setShow(false);
     let parsedSchema = parse(schema.content);
+    console.log(schema, parsedSchema)
     handleParsedSchema(parsedSchema);
     let splitRes = splitTablesEdges(parsedSchema);
     handleStateChange(splitRes[0], splitRes[1], splitRes[2]);

--- a/utils/coordinate.js
+++ b/utils/coordinate.js
@@ -1,3 +1,6 @@
+import { InvalidGraphTypes } from "./types.js"
+import { getGraph, topoSort } from './graph.js';
+
 // height between two levels is roughly 100 px's
 var MAXNODEWIDTH = 200
 var MAXNODEHEIGHT = 30
@@ -12,9 +15,13 @@ function topLeftAlign(centerX, centerY, nodeW, nodeH) {
 
 // Return a hashmap that maps table names to coordinates.
 // The coordinates indicate the center positions of nodes
-export function calculateCoordinates(sortedNodes, G, canvasW, canvasH) {
-    var coords = new Map()
+export function calculateCoordinates(invalidType, objects, canvasW, canvasH) {
+    // check invalid type and decide how to place nodes accordingly
+    if (invalidType === InvalidGraphTypes.None) {
+        var sortedNodes = topoSort(getGraph(objects))
+    }
 
+    var coords = {}
     // calculate the height assigned to each level
     var heightPerLevel = canvasH / sortedNodes.length
 

--- a/utils/coordinate.js
+++ b/utils/coordinate.js
@@ -1,5 +1,5 @@
 import { InvalidGraphTypes } from "./types.js"
-import { getGraph, topoSort } from './graph.js';
+import { topoSort } from './graph.js';
 
 // height between two levels is roughly 100 px's
 var MAXNODEWIDTH = 200
@@ -18,7 +18,7 @@ function topLeftAlign(centerX, centerY, nodeW, nodeH) {
 export function calculateCoordinates(invalidType, objects, canvasW, canvasH) {
     // check invalid type and decide how to place nodes accordingly
     if (invalidType === InvalidGraphTypes.None) {
-        var sortedNodes = topoSort(getGraph(objects))
+        var sortedNodes = topoSort(objects).reverse()
     }
 
     var coords = {}

--- a/utils/graph.js
+++ b/utils/graph.js
@@ -13,7 +13,7 @@ export function getGraph(parsedObjects) {
     }
 
     // create an adjacency list
-    const G = new Map();
+    const G = {};
     for (const node of nodes) {
         // G.set(node, new Set())
         G[node] = new Set()
@@ -31,7 +31,7 @@ inDegree 0, B and C have inDegree 1 and D has inDegree 2.
 If the graph is invalid (has a cycle), returns an empty list */
 export function topoSort(G) {
     // create an inNodes graph (reverse graph) from the input graph
-    const inNodes = new Map();
+    const inNodes = {};
     for (const node in G) {
         inNodes[node] = new Set()
     }
@@ -64,10 +64,7 @@ export function topoSort(G) {
         res.push(q)
         q = nextQ
     }
-    // 4. check if the graph is a DAG
-    if (processedNodeCt < inNodes.keys().length) {
-        return []
-    } else {
-        return res
-    }
+    // 4. returns processed node in topological order; 
+    // If there's a cycle, only return nodes that are not in the cycle
+    return res
 }

--- a/utils/interface.js
+++ b/utils/interface.js
@@ -1,25 +1,19 @@
-export const Annotations = {
-    DataSubject: "data_subject",
-    OwnedBy: "owned_by",
-    AccessedBy: "accessed_by",
-    Owns: "owns",
-    Accesses: "accesses"
-}
+import { parse } from "./parse.js"
+import { getGraph, topoSort } from './graph.js';
+import { calculateCoordinates } from './coordinate.js'
+import { validate } from "./validate.js"
 
-/*
-export class Node {
-    constructor(tableName, isDataSubject) {
-        this.tableName = tableName
-        this.isDataSubject = isDataSubject
-    }
-}
 
-export class Edge {
-    constructor(annotation, fromNode, toNode, fieldName) {
-        this.annotation = annotation,
-        this.fromNode = fromNode,
-        this.toNode = toNode,
-        this.fieldName = fieldName
-    }
+export default function getObjectsAndCoords(inputStr, canvasW, canvasH) {
+    // 1. Parse the input string to a list of node or edge objects
+    let parsedObjects = parse(inputStr)
+
+    // 2. Build a graph and validate if the graph is valid.
+    // If not, the `errMsg` will be added to problem edges
+    let [invalidType, modifiedObjects] = validate(parsedObjects)
+
+    // 3. Pass objects with potentially error messages to the coordinate calculation function
+    let coordsMap = calculateCoordinates(invalidType, modifiedObjects, canvasW, canvasH)
+
+    return [modifiedObjects, coordsMap]
 }
-*/

--- a/utils/interface.js
+++ b/utils/interface.js
@@ -1,19 +1,22 @@
 import { parse } from "./parse.js"
-import { getGraph, topoSort } from './graph.js';
 import { calculateCoordinates } from './coordinate.js'
 import { validate } from "./validate.js"
 
-
-export default function getObjectsAndCoords(inputStr, canvasW, canvasH) {
-    // 1. Parse the input string to a list of node or edge objects
-    let parsedObjects = parse(inputStr)
-
-    // 2. Build a graph and validate if the graph is valid.
+// return a list of parsed objects and a coordinate map that maps nodes to coordinates
+export function getCoords(parsedObjects, canvasW, canvasH) {
+    // 1. Build a graph and validate if the graph is valid.
     // If not, the `errMsg` will be added to problem edges
     let [invalidType, modifiedObjects] = validate(parsedObjects)
+    console.log("Interface 10: ", invalidType, modifiedObjects)
 
-    // 3. Pass objects with potentially error messages to the coordinate calculation function
+    // 2. Pass objects with potentially error messages to the coordinate calculation function
     let coordsMap = calculateCoordinates(invalidType, modifiedObjects, canvasW, canvasH)
 
+    console.log("Interface 15: ", coordsMap)
     return [modifiedObjects, coordsMap]
+}
+
+// return a list of parsed objects and a coordinate map that maps nodes to coordinates
+export function getObjectsAndCoords(inputStr, canvasW, canvasH) {
+    return getCoords(parse(inputStr), canvasW, canvasH)
 }

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -137,15 +137,15 @@ function parseCreateStatement(statement, pkMap) {
     let tableName = parseTableName(statement)
 
     // check if the annotation, 'data_subject', exists
+    let res = []
     if (statement.includes(Annotations.DataSubject)) {
-        return [{
+        res.push({
             annotation: "data_subject",
             tableName: tableName
-        }];
+        })
     }
 
     // construct an array of Edge objects
-    let res = []
     const sentences = parseSentences(statement)
     for (const sentence of sentences) {
         let dict = parseEdge(sentence, tableName, pkMap)

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -1,5 +1,4 @@
-import { Annotations } from "./interface.js"
-
+import { Annotations } from "./types.js"
 
 // Given an array of SQL create statements as an input string,
 // return a list of sanitized sentences where in each sentence,
@@ -159,17 +158,15 @@ function parseCreateStatement(statement, pkMap) {
 
 /* Parse API
 Given an array of SQL create statements with K9db annotations as an input string,
-returns a list of Node and Edge objects. 
-If any statement is invalid, empty array will be returned. */
-export default function parse(inputStr) {
+returns a list of Node and Edge objects. */
+export function parse(inputStr) {
+    // 1. parse the input string into a list of edge/node objects
     let statements = getSanitizedStatements(inputStr)
-    // console.log("sanitized: ", statements)
     let pkMap = getPrimaryKeyMap(statements)
-    console.log("Primary key map: ", pkMap)
 
-    var res = []
+    var parsedObjects = []
     for (const statement of statements) {
-        res.push(...parseCreateStatement(statement, pkMap))
+        parsedObjects.push(...parseCreateStatement(statement, pkMap))
     }
-    return res
+    return parsedObjects
 }

--- a/utils/splitTableEdges.tsx
+++ b/utils/splitTableEdges.tsx
@@ -1,24 +1,16 @@
-import { getGraph, topoSort } from "./graph.js";
-import { calculateCoordinates } from "./coordinate.js";
+import { getCoords } from "./interface.js"
 
-const splitTablesEdges = function (parsedSchema) {
-  var graph = getGraph(parsedSchema);
-  var sortedNodes = topoSort(graph);
+const splitTablesEdges = function (parsedObjects) {
   var canvasWidth = 1000;
-  var canvasHeight = 1000;
-  var coordsMap = calculateCoordinates(
-    sortedNodes,
-    graph,
-    canvasWidth,
-    canvasHeight
-  );
+  var canvasHeight = 500;
+  let [modifiedObjects, coordsMap] = getCoords(parsedObjects, canvasWidth, canvasHeight)
   let dataSubjects: any[] = [];
   let otherTables: any[] = [];
 
   //storing edge objects. ex: {annotation: 'owned_by', from: 'stories', to: 'user', edgeName: 'author'}
   let edges: any[] = [];
 
-  for (const row of parsedSchema) {
+  for (const row of modifiedObjects) {
     if (row.annotation === "data_subject") {
       dataSubjects.push(row.tableName);
     } else {
@@ -26,7 +18,7 @@ const splitTablesEdges = function (parsedSchema) {
     }
   }
 
-  for (const row of parsedSchema) {
+  for (const row of modifiedObjects) {
     if (row.annotation !== "data_subject") {
       if (!dataSubjects.includes(row.from) && !otherTables.includes(row.from)) {
         otherTables.push(row.from);

--- a/utils/statements.js
+++ b/utils/statements.js
@@ -65,13 +65,30 @@ export const flowAgainstDataSubject1 = `
     );
 `
 
-export const twoNodesCycle = `
+// A <-> B
+export const twoNodesCycle1 = `
     CREATE DATA_SUBJECT TABLE A (
         id INT PRIMARY KEY,
-        a_a INT NOT NULL OWNED_BY B(id)
+        a1 INT NOT NULL OWNED_BY B(id)
     );
     CREATE TABLE B (
         id INT PRIMARY KEY,
         b1 INT NOT NULL OWNED_BY A(id)
     );
+`
+
+// C -> A <-> B
+export const twoNodesCycle2 = `
+CREATE DATA_SUBJECT TABLE A (
+    id INT PRIMARY KEY,
+    a1 INT NOT NULL OWNED_BY B(id)
+);
+CREATE TABLE B (
+    id INT PRIMARY KEY,
+    a2 INT NOT NULL OWNED_BY A(id)
+);
+CREATE TABLE C (
+    id INT PRIMARY KEY,
+    c1 INT NOT NULL OWNED_BY A(id)
+);
 `

--- a/utils/statements.js
+++ b/utils/statements.js
@@ -53,3 +53,25 @@ export const ownCloudStatements = `
         share_with_group INT ACCESSED_BY group(id)
     );
 `
+
+export const flowAgainstDataSubject1 = `
+    CREATE DATA_SUBJECT TABLE A (
+        id INT PRIMARY KEY,
+        a_a INT NOT NULL OWNED_BY B(id)
+    );
+    CREATE TABLE B (
+        id INT PRIMARY KEY,
+
+    );
+`
+
+export const twoNodesCycle = `
+    CREATE DATA_SUBJECT TABLE A (
+        id INT PRIMARY KEY,
+        a_a INT NOT NULL OWNED_BY B(id)
+    );
+    CREATE TABLE B (
+        id INT PRIMARY KEY,
+        b1 INT NOT NULL OWNED_BY A(id)
+    );
+`

--- a/utils/test.js
+++ b/utils/test.js
@@ -1,10 +1,14 @@
-import getObjectsAndCoords from './interface.js';
-import { lobstersStatements, ownCloudStatements } from './statements.js'
+import { getObjectsAndCoords } from './interface.js';
+import * as statements from './statements.js'
 
 let canvasWidth = 1000
 let canvasHeight = 1000
 
 // test lobstersStatements
-let [objects, coordsMap] = getObjectsAndCoords(lobstersStatements, canvasWidth, canvasHeight)
-console.log(objects)
-console.log(coordsMap)
+// let [objects, coordsMap] = getObjectsAndCoords(statements.lobstersStatements, canvasWidth, canvasHeight)
+
+// test cycles of two nodes
+let [objects, coordsMap] = getObjectsAndCoords(statements.twoNodesCycle1, canvasWidth, canvasHeight)
+// let [objects, coordsMap] = getObjectsAndCoords(statements.twoNodesCycle2, canvasWidth, canvasHeight)
+// console.log(objects)
+// console.log(coordsMap)

--- a/utils/test.js
+++ b/utils/test.js
@@ -1,19 +1,10 @@
-import parse from './parse.js';
-import { getGraph, topoSort } from './graph.js';
-import { calculateCoordinates } from './coordinate.js'
+import getObjectsAndCoords from './interface.js';
 import { lobstersStatements, ownCloudStatements } from './statements.js'
 
-// get graph and topologically-sorted nodes
-var parsedObjects = parse(lobstersStatements)
-// var parsedObjects = parse(ownCloudStatements)
-console.log(parsedObjects)
-var graph = getGraph(parsedObjects)
-var sortedNodes = topoSort(graph)
-console.log(graph)
-console.log(sortedNodes)
+let canvasWidth = 1000
+let canvasHeight = 1000
 
-// calculate coordinates
-var canvasWidth = 1000
-var canvasHeight = 1000
-var coords = calculateCoordinates(sortedNodes, graph, canvasWidth, canvasHeight)
-console.log(coords)
+// test lobstersStatements
+let [objects, coordsMap] = getObjectsAndCoords(lobstersStatements, canvasWidth, canvasHeight)
+console.log(objects)
+console.log(coordsMap)

--- a/utils/types.js
+++ b/utils/types.js
@@ -1,0 +1,20 @@
+export const Annotations = {
+    DataSubject: "data_subject",
+    OwnedBy: "owned_by",
+    AccessedBy: "accessed_by",
+    Owns: "owns",
+    Accesses: "accesses"
+}
+
+export function isEdgeObject(object) {
+    return object.annotation !== Annotations.DataSubject
+}
+
+// what type of problem does the graph have
+export const InvalidGraphTypes = Object.freeze({
+    None: "None",
+    Cycle: "Cycle",
+    NoDataSubject: "NoDataSubject",
+    MultipleDataSubjects: "MultipleDataSubjects",
+    DataSubjectOutEdge: "DataSubjectOutEdge"
+})

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -1,4 +1,4 @@
-import { getGraph, topoSort } from './graph.js';
+import { getAllNodes, topoSort } from './graph.js';
 import { isEdgeObject, InvalidGraphTypes } from "./types.js"
 
 /* Detect if there's a cycle in the graph. If there's a cycle,
@@ -9,8 +9,7 @@ have one and only one outgoing edge that's in the cycle.
 
 returns true to indicate there's a cycle; edge object in a cycle will have errMsg added
 */
-function detectCycle(G, parsedObjects) {
-    console.log(parsedObjects)
+function detectCycle(parsedObjects) {
     // map fromNodes to edge objects
     let fromNodeMap = {}
     let resObjects = []
@@ -23,7 +22,7 @@ function detectCycle(G, parsedObjects) {
         }
     }
     // get the set of nodes that are not in the cycle
-    let topoSortedList = topoSort(G)
+    let topoSortedList = topoSort(parsedObjects)
     let nonCycleSet = new Set()
     for (const level of topoSortedList) {
         for (const node of level) {
@@ -31,26 +30,29 @@ function detectCycle(G, parsedObjects) {
         }
     }
 
-    let allNodes = Object.keys(G)
-    console.log(nonCycleSet, allNodes)
+    let allNodes = getAllNodes(parsedObjects)
+    let hasCycle = false
     for (const node of allNodes) {
         if (!nonCycleSet.has(node)) {
             // add the cycle error message to the object corresponding to this node
-            console.log("Hi")
+            hasCycle = true
+            let obj = fromNodeMap[node]
+            obj["errorMsg"] = "This edge is in a cycle"
+            resObjects.push(obj)
         }
     }
+
+    return [hasCycle, resObjects]
 }
 
 // Given a list of parsed objects (edge objects and node objects)
 // return a list of objects with potential error messages added to the objects
 export function validate(parsedObjects) {
-    let G = getGraph(parsedObjects)
-
     // 1. Check if any cycle exists
-    // let [hasCycle, modifiedObjects] = detectCycle(G, parsedObjects)
-    // if (hasCycle) {
-    //     return [InvalidGraphTypes.Cycle, modifiedObjects]
-    // }
+    let [hasCycle, modifiedObjects] = detectCycle(parsedObjects)
+    if (hasCycle) {
+        return [InvalidGraphTypes.Cycle, modifiedObjects]
+    }
 
     // 2. TODO: Check if there's no data subject
 

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -1,0 +1,63 @@
+import { getGraph, topoSort } from './graph.js';
+import { isEdgeObject, InvalidGraphTypes } from "./types.js"
+
+/* Detect if there's a cycle in the graph. If there's a cycle,
+add error messages to all edges that belong to this cycle.
+Because every node has at most one outgoing edge, any node that hasn't 
+been visited after Khan's algorithm is in the cycle, and this node must
+have one and only one outgoing edge that's in the cycle.
+
+returns true to indicate there's a cycle; edge object in a cycle will have errMsg added
+*/
+function detectCycle(G, parsedObjects) {
+    console.log(parsedObjects)
+    // map fromNodes to edge objects
+    let fromNodeMap = {}
+    let resObjects = []
+    for (const obj of parsedObjects) {
+        if (isEdgeObject(obj)) {
+            fromNodeMap[obj.from] = obj
+        } else {
+            // non edge objects will be added to the result 
+            resObjects.push(obj)
+        }
+    }
+    // get the set of nodes that are not in the cycle
+    let topoSortedList = topoSort(G)
+    let nonCycleSet = new Set()
+    for (const level of topoSortedList) {
+        for (const node of level) {
+            nonCycleSet.add(node)
+        }
+    }
+
+    let allNodes = Object.keys(G)
+    console.log(nonCycleSet, allNodes)
+    for (const node of allNodes) {
+        if (!nonCycleSet.has(node)) {
+            // add the cycle error message to the object corresponding to this node
+            console.log("Hi")
+        }
+    }
+}
+
+// Given a list of parsed objects (edge objects and node objects)
+// return a list of objects with potential error messages added to the objects
+export function validate(parsedObjects) {
+    let G = getGraph(parsedObjects)
+
+    // 1. Check if any cycle exists
+    // let [hasCycle, modifiedObjects] = detectCycle(G, parsedObjects)
+    // if (hasCycle) {
+    //     return [InvalidGraphTypes.Cycle, modifiedObjects]
+    // }
+
+    // 2. TODO: Check if there's no data subject
+
+    // 3. TODO: Check if there's more than one data subject
+
+    // 4. TODO: Check if all edges flow to the data subject
+
+    // no error; original parsedObjects are returned
+    return [InvalidGraphTypes.None, parsedObjects]
+}


### PR DESCRIPTION
The front-end only needs to import one of the two functions in `interface.js` now. 

- `getObjectsAndCoords(inputStr, ...)` takes the raw string from the submission box
- `getCoords(parsedObjects, ...)` takes the parsed objects after calling `parse(rawInputStr)` from parse.js for compatibility