### PR TITLE
Fix parser sanitize bug

### DIFF
--- a/utils/parse.js
+++ b/utils/parse.js
@@ -6,18 +6,19 @@ import { Annotations } from "./types.js"
 // extra spaces/tabs are removed and all charactes are lowered
 function getSanitizedStatements(inputStr) {
     // split the input string by the `CREATE` keyword into an array of sentences
+    var tableRegex = /(create\s+table)\s+/g;
+    var dsRegex = /(create\s+data_subject)\s+/g;;
     let statements = inputStr.trim().split(/(?=CREATE)/)
     let sanitized = []
     for (let statement of statements) {
         statement = statement.toLowerCase()
-        if (statement.includes("create table") ||
-            statement.includes("create data_subject")) {
+            if (tableRegex.test(statement) || dsRegex.test(statement)){
             // remove extra spaces and tabs
-            statement = statement.replace(/[\n\t\r]/g, '')
+            statement = statement.replace(tableRegex, '$1 ')
+            statement = statement.replace(dsRegex, '$1 ')
             sanitized.push(statement)
         }
     }
-
     return sanitized
 }
 

--- a/utils/statements.js
+++ b/utils/statements.js
@@ -29,6 +29,34 @@ export const lobstersStatements = `
     );
 `
 
+export const extraSpaceLobstersStatements = `
+    CREATE  DATA_SUBJECT TABLE users (
+        id INT PRIMARY KEY
+    );
+    CREATE TABLE   stories (
+        id INT PRIMARY KEY,
+        title TEXT,
+        author INT NOT NULL OWNED_BY users(id) 
+    );
+    CREATE TABLE  tags (
+        id INT PRIMARY KEY,
+        tag TEXT
+    );
+    CREATE TABLE    taggings (
+        id INT PRIMARY KEY,
+        story_id INT NOT NULL OWNED_BY stories(id), 
+        tag_id INT NOT NULL ACCESSES tags(id)
+    );
+    CREATE   TABLE   messages (
+        id INT PRIMARY KEY, 
+        body text, 
+        sender INT NOT NULL OWNED_BY users(id), 
+        receiver INT NOT NULL OWNED_BY users(id), 
+        ON DEL sender ANON (sender),
+        ON DEL receiver ANON (receiver)
+    );
+`
+
 
 // Partial schema for ownCloud file sharing in the K9db paper
 export const ownCloudStatements = `


### PR DESCRIPTION
Before the fix, the parser did not get rid of extra spaces between CREATE and the table name. 

Right now, our parser is able to handle the schema with extra spaces like below
```
    CREATE  DATA_SUBJECT TABLE users (
        id INT PRIMARY KEY
    );
    CREATE TABLE   stories (
        id INT PRIMARY KEY,
        title TEXT,
        author INT NOT NULL OWNED_BY users(id) 
    );
    CREATE TABLE  tags (
        id INT PRIMARY KEY,
        tag TEXT
    );
    CREATE TABLE    taggings (
        id INT PRIMARY KEY,
        story_id INT NOT NULL OWNED_BY stories(id), 
        tag_id INT NOT NULL ACCESSES tags(id)
    );
    CREATE   TABLE   messages (
        id INT PRIMARY KEY, 
        body text, 
        sender INT NOT NULL OWNED_BY users(id), 
        receiver INT NOT NULL OWNED_BY users(id), 
        ON DEL sender ANON (sender),
        ON DEL receiver ANON (receiver)
    );
```
